### PR TITLE
Bugfix: Make Scrollbar Control Transparent

### DIFF
--- a/theme/2077 theme-color-theme.json
+++ b/theme/2077 theme-color-theme.json
@@ -664,9 +664,9 @@
 
 		// Scrollbar Control
 		"scrollbar.shadow":"#992293",
-		"scrollbarSlider.activeBackground":"#d31b77",
-		"scrollbarSlider.background":"#ee0077",
-		"scrollbarSlider.hoverBackground":"#5994CE",
+		"scrollbarSlider.activeBackground":"#d31b7755",
+		"scrollbarSlider.background":"#ee007755",
+		"scrollbarSlider.hoverBackground":"#5994CE55",
 
 		// Activity Bar
 		"activityBar.background": "#030d22",


### PR DESCRIPTION
Bugfix: Making the Scrollbar control transparent allows warning, error, and current line indicators to be visible.

See the difference between the attached screenshot.

## Before Updates
![Screenshot from 2020-03-06 22-29-29](https://user-images.githubusercontent.com/570910/76136690-0d6e0c00-5ffa-11ea-80d2-0e69ea40dafe.png)

## With Updates
![Screenshot from 2020-03-06 22-27-24](https://user-images.githubusercontent.com/570910/76136687-06df9480-5ffa-11ea-9961-d68794535fd8.png)