### PR TITLE
Fixes text colors inside html tags in JSX files

### DIFF
--- a/theme/2077 theme-color-theme.json
+++ b/theme/2077 theme-color-theme.json
@@ -92,7 +92,7 @@
 			"meta.jsx.children.tsx"
 		  ],
 		"settings": {
-			"foreground": "#ff2e97"
+			"foreground": "#fdfeff"
 		}
 	},
 	{


### PR DESCRIPTION
Fixes text content colors inside html tags for JSX files. As show below:

- Now:
<img width="882" alt="Screen Shot 2020-07-22 at 8 46 51 AM" src="https://user-images.githubusercontent.com/19212953/88173311-bce9fa80-cbf8-11ea-8554-6d119595f120.png">

- PR:
<img width="882" alt="Screen Shot 2020-07-22 at 8 45 56 AM" src="https://user-images.githubusercontent.com/19212953/88173347-c96e5300-cbf8-11ea-87df-2c94f9043714.png">
